### PR TITLE
Integrate HTTP logging middleware with structlog

### DIFF
--- a/api/src/api/main.py
+++ b/api/src/api/main.py
@@ -4,6 +4,8 @@ import structlog
 from asgi_correlation_id import CorrelationIdMiddleware, correlation_id
 from fastapi import FastAPI, Request
 
+from api.middleware.logging import HTTPLogMiddleware
+
 from .logging_config import setup_logging
 
 # Determine environment: production if APP_ENV=production, else development
@@ -14,6 +16,8 @@ IS_PRODUCTION = APP_ENV == "production"
 setup_logging(is_json_logs=IS_PRODUCTION)
 
 app = FastAPI()
+
+app.add_middleware(HTTPLogMiddleware)
 
 # Add correlation ID middleware
 app.add_middleware(

--- a/api/src/api/middleware/logging.py
+++ b/api/src/api/middleware/logging.py
@@ -1,0 +1,47 @@
+import time
+
+import structlog
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+# Use structlog logger for structured logging
+logger = structlog.get_logger(__name__)
+
+class HTTPLogMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to log HTTP requests and responses, including headers.
+    """
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        start_time = time.time()
+
+        # Process the request and get the response
+        response = await call_next(request)
+
+        process_time = (time.time() - start_time) * 1000
+
+        # Attempt to get correlation_id from request state, falling back to a header
+        correlation_id = getattr(request.state, "correlation_id", "N/A")
+        if correlation_id == "N/A":
+            correlation_id = request.headers.get("X-Request-ID", "N/A")
+
+        # Convert headers to dict for logging
+        request_headers = dict(request.headers)
+        response_headers = dict(response.headers)
+
+        log_details = {
+            "method": request.method,
+            "url": str(request.url),
+            "status_code": response.status_code,
+            "process_time_ms": f"{process_time:.2f}",
+            "correlation_id": correlation_id,
+            "client_ip": request.client.host if request.client else "N/A",
+            "request_headers": request_headers,
+            "response_headers": response_headers,
+        }
+
+        logger.info("HTTP Request Completed", http=log_details)
+
+        return response


### PR DESCRIPTION
**PR title**: Integrate HTTP logging middleware with structlog
---
**PR description**:
* Added HTTPLogMiddleware to log HTTP requests and responses, including headers
* Switched to structlog for structured logging output
* Ensured logs include request/response headers, correlation ID, and timing
* No changes to dependencies
